### PR TITLE
feat: added an option to delete a field

### DIFF
--- a/src/components/form-builder.tsx
+++ b/src/components/form-builder.tsx
@@ -15,7 +15,7 @@ interface FormBuilderProps {
   setFormFields: React.Dispatch<React.SetStateAction<FormField[]>>;
 }
 
-const FormBuilder: FC<FormBuilderProps> = ({ formFields }) => {
+const FormBuilder: FC<FormBuilderProps> = ({ formFields, setFormFields }) => {
   const { setNodeRef } = useDroppable({ id: 'form-builder' });
   return (
     <div
@@ -32,7 +32,14 @@ const FormBuilder: FC<FormBuilderProps> = ({ formFields }) => {
           <p className='text-gray-400'>Drag form elements here</p>
         )}
         {formFields.map((field) => (
-          <SortableItem key={field.key} id={field.key} label={field.label} />
+          <SortableItem
+            key={field.key}
+            id={field.key}
+            label={field.label}
+            onDelete={(id) =>
+              setFormFields((prev) => prev.filter((f) => f.key !== id))
+            }
+          />
         ))}
       </SortableContext>
     </div>
@@ -41,12 +48,11 @@ const FormBuilder: FC<FormBuilderProps> = ({ formFields }) => {
 
 export default FormBuilder;
 
-interface SortableItemProps {
-  id: string;
-  label: string;
+interface SortableItemProps extends FormField {
+  onDelete: (id: string) => void;
 }
 
-function SortableItem({ id, label }: SortableItemProps) {
+function SortableItem({ id, label, onDelete }: SortableItemProps) {
   const {
     attributes,
     listeners,
@@ -66,11 +72,30 @@ function SortableItem({ id, label }: SortableItemProps) {
     borderRadius: '0.25rem',
     backgroundColor: 'white',
     cursor: 'grab',
+    display: 'flex',
   };
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      {label}
+    <div ref={setNodeRef} style={style}>
+      {/* Left: Drag handle only */}
+      <div
+        {...attributes}
+        {...listeners}
+        className='cursor-grab text-gray-500 hover:text-black'
+        title='Drag to reorder'
+      >
+        ☰
+      </div>
+
+      <div className='flex-1 px-2'>{label}</div>
+
+      <button
+        onClick={() => onDelete(id)}
+        className='text-red-500 hover:text-red-700'
+        aria-label={`Delete ${label}`}
+      >
+        🗑️
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
**Why?**

- Form builder users need the ability to remove unwanted fields.
- Previously, there was no way to delete a field once added.
- Attempting to add a delete button failed due to drag listeners capturing all clicks, breaking usability.

**What?**

- Added a 🗑️ Delete button to each form field in the builder.
- Introduced a dedicated drag handle (☰) instead of dragging the full field area.
- Updated component structure to allow safe and accessible field interaction (drag vs. click).

**How?**
- ```SortableItem``` now accepts an onDelete prop and renders a delete button inside.
- Drag listeners (attributes, listeners) moved only to a small div acting as the drag handle.
- CSS updated to style the handle and ensure pointer behavior is intuitive.

  ```tsx
  <div className="flex items-center justify-between">
    <div className="cursor-grab mr-2" {...listeners} {...attributes}>
      ☰
    </div>
    <span>{label}</span>
    <button onClick={() => onDelete(id)}>🗑️</button>
  </div>
  ```

**Demo?**

https://github.com/user-attachments/assets/009bd85b-c7cb-4d6c-a521-5aebcac5de13


**Anything else?**
- Hydration mismatches avoided by ensuring stable props and avoiding runtime-only values.
- Proper key handling maintained for reordering and deleting.
- All changes are backward-compatible with the previous form state and structure.

**What next?**
- ✏️ Editable field labels — allow users to rename fields inline.
- ⚙️ Field settings modal — options for required, placeholder, options (for select).
- 💾 Export form as JSON schema.
- 📥 Import from JSON.
- 🧪 Add unit tests for drag/delete logic.